### PR TITLE
feat: add basic availability UI

### DIFF
--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -1,64 +1,24 @@
 import "package:flutter/material.dart";
+import "package:flutter_availability/flutter_availability.dart";
 
 void main() {
-  runApp(const MyApp());
+  runApp(const App());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class App extends StatelessWidget {
+  const App({super.key});
 
   @override
-  Widget build(BuildContext context) => MaterialApp(
-        title: "Flutter Demo",
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-          useMaterial3: true,
-        ),
-        home: const MyHomePage(title: "Flutter Demo Home Page"),
+  Widget build(BuildContext context) => const MaterialApp(
+        home: Home(),
       );
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({required this.title, super.key});
-  final String title;
+class Home extends StatelessWidget {
+  const Home({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) => Scaffold(
-        appBar: AppBar(
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-          title: Text(widget.title),
-        ),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              const Text(
-                "You have pushed the button this many times:",
-              ),
-              Text(
-                "$_counter",
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-            ],
-          ),
-        ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: _incrementCounter,
-          tooltip: "Increment",
-          child: const Icon(Icons.add),
-        ), // This trailing comma makes auto-formatting nicer for build methods.
+  Widget build(BuildContext context) => availabilityNavigatorUserStory(
+        context,
       );
 }

--- a/packages/flutter_availability/lib/flutter_availability.dart
+++ b/packages/flutter_availability/lib/flutter_availability.dart
@@ -1,8 +1,8 @@
 ///
 library flutter_availability;
 
-/// A Calculator.
-class Calculator {
-  /// Returns [value] plus 1.
-  int addOne(int value) => value + 1;
-}
+export "src/config/availability_options.dart";
+export "src/config/availability_translations.dart";
+export "src/screens/availability_overview.dart";
+export "src/userstory/navigator_userstory.dart";
+export "src/userstory/userstory_configuration.dart";

--- a/packages/flutter_availability/lib/src/config/availability_options.dart
+++ b/packages/flutter_availability/lib/src/config/availability_options.dart
@@ -1,0 +1,12 @@
+import "package:flutter_availability/src/config/availability_translations.dart";
+
+/// Class that holds all options for the availability userstory
+class AvailabilityOptions {
+  /// AvailabilityOptions constructor where everything is optional.
+  const AvailabilityOptions({
+    this.translations = const AvailabilityTranslations.empty(),
+  });
+
+  /// The translations for the availability userstory
+  final AvailabilityTranslations translations;
+}

--- a/packages/flutter_availability/lib/src/config/availability_translations.dart
+++ b/packages/flutter_availability/lib/src/config/availability_translations.dart
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 Iconica
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Class that holds all translatable strings for the availability userstory
+class AvailabilityTranslations {
+  /// AvailabilityTranslations constructor where everything is required.
+  /// If you want to have a default value, use the `empty` constructor.
+  /// You can copyWith the values to override some default translations.
+  /// It is recommended to use this constructor.
+  const AvailabilityTranslations({
+    required this.calendarTitle,
+    required this.addAvailableDayButtonText,
+    required this.availabilityOverviewTitle,
+    required this.availabilityDate,
+    required this.availabilityHours,
+    required this.availabilityEmptyMessage,
+    required this.availabilitySubmit,
+    required this.availabilitySave,
+  });
+
+  /// AvailabilityTranslations constructor where everything is optional.
+  /// This provides default english values for the availability userstory.
+  const AvailabilityTranslations.empty({
+    this.calendarTitle = "Availability",
+    this.addAvailableDayButtonText = "Add availability",
+    this.availabilityOverviewTitle = "Overview of your availabilities",
+    this.availabilityDate = "Date",
+    this.availabilityHours = "Hours",
+    this.availabilityEmptyMessage =
+        "No availabilities filled in for this month",
+    this.availabilitySubmit = "Submit",
+    this.availabilitySave = "Save",
+  });
+
+  /// The title shown above the calendar
+  final String calendarTitle;
+
+  /// The text shown on the button to add an available day
+  final String addAvailableDayButtonText;
+
+  /// The title for the overview of the availabilities
+  final String availabilityOverviewTitle;
+
+  /// The label for the date of an availability
+  final String availabilityDate;
+
+  /// The label for the hours of an availability
+  final String availabilityHours;
+
+  /// The text shown when there are no availabilities filled in for a month
+  final String availabilityEmptyMessage;
+
+  /// The text shown on the button to submit the availabilities
+  final String availabilitySubmit;
+
+  /// The text shown on the button to save a single availability
+  final String availabilitySave;
+
+  /// Method to update the translations with new values
+  AvailabilityTranslations copyWith({
+    String? calendarTitle,
+    String? addAvailableDayButtonText,
+    String? availabilityOverviewTitle,
+    String? availabilityDate,
+    String? availabilityHours,
+    String? availabilityEmptyMessage,
+    String? availabilitySubmit,
+    String? availabilitySave,
+  }) =>
+      AvailabilityTranslations(
+        calendarTitle: calendarTitle ?? this.calendarTitle,
+        addAvailableDayButtonText:
+            addAvailableDayButtonText ?? this.addAvailableDayButtonText,
+        availabilityOverviewTitle:
+            availabilityOverviewTitle ?? this.availabilityOverviewTitle,
+        availabilityDate: availabilityDate ?? this.availabilityDate,
+        availabilityHours: availabilityHours ?? this.availabilityHours,
+        availabilityEmptyMessage:
+            availabilityEmptyMessage ?? this.availabilityEmptyMessage,
+        availabilitySubmit: availabilitySubmit ?? this.availabilitySubmit,
+        availabilitySave: availabilitySave ?? this.availabilitySave,
+      );
+}

--- a/packages/flutter_availability/lib/src/screens/availability_day_overview.dart
+++ b/packages/flutter_availability/lib/src/screens/availability_day_overview.dart
@@ -1,0 +1,452 @@
+import "package:flutter/material.dart";
+import "package:flutter_availability/src/config/availability_options.dart";
+import "package:flutter_availability_data_interface/flutter_availability_data_interface.dart";
+import "package:intl/intl.dart";
+
+///
+class AvailabilityDayOverview extends StatefulWidget {
+  ///
+  const AvailabilityDayOverview({
+    required this.userId,
+    required this.service,
+    required this.options,
+    required this.date,
+    required this.onAvailabilitySaved,
+    this.initialAvailability,
+    super.key,
+  });
+
+  /// The user whose availability is being managed
+  final String userId;
+
+  /// The service to use for managing availability
+  final AvailabilityDataInterface service;
+
+  /// The configuration option for the availability overview
+  final AvailabilityOptions options;
+
+  /// The date for which the availability is being managed
+  final DateTime date;
+
+  /// The initial availability for the day
+  final AvailabilityModel? initialAvailability;
+
+  /// Callback for when the availability is saved
+  final Function() onAvailabilitySaved;
+
+  @override
+  State<AvailabilityDayOverview> createState() =>
+      _AvailabilityDayOverviewState();
+}
+
+class _AvailabilityDayOverviewState extends State<AvailabilityDayOverview> {
+  late TextEditingController _startDateController;
+  late TextEditingController _endDateController;
+  late AvailabilityModel _availability;
+  bool _clearAvailableToday = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _availability = widget.initialAvailability ??
+        AvailabilityModel(
+          userId: widget.userId,
+          startDate: widget.date,
+          endDate: widget.date,
+          breaks: [],
+        );
+    _startDateController = TextEditingController(
+      text: DateFormat("HH:mm").format(_availability.startDate),
+    );
+    _endDateController = TextEditingController(
+      text: DateFormat("HH:mm").format(_availability.endDate),
+    );
+  }
+
+  @override
+  void dispose() {
+    _startDateController.dispose();
+    _endDateController.dispose();
+    super.dispose();
+  }
+
+  Future<TimeOfDay?> _selectTime(TextEditingController controller) async {
+    var picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+    if (picked != null) {
+      setState(() {
+        controller.text = picked.format(context);
+      });
+      return picked;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Future<void> updateAvailabilityStart() async {
+      var selectedTime = await _selectTime(_startDateController);
+      if (selectedTime == null) return;
+
+      var updatedStartDate = _availability.startDate.copyWith(
+        hour: selectedTime.hour,
+        minute: selectedTime.minute,
+      );
+      setState(() {
+        _availability = _availability.copyWith(startDate: updatedStartDate);
+      });
+    }
+
+    Future<void> updateAvailabilityEnd() async {
+      var selectedTime = await _selectTime(_endDateController);
+      if (selectedTime == null) return;
+
+      var updatedEndDate = _availability.endDate.copyWith(
+        hour: selectedTime.hour,
+        minute: selectedTime.minute,
+      );
+      setState(() {
+        _availability = _availability.copyWith(endDate: updatedEndDate);
+      });
+    }
+
+    Future<void> onClickAddPause() async {
+      var newBreak = await AvailabilityBreakSelectionDialog.show(context, null);
+      if (newBreak != null) {
+        setState(() {
+          _availability.breaks.add(newBreak);
+        });
+      }
+    }
+
+    Future<void> onClickSave() async {
+      if (_clearAvailableToday) {
+        // remove the availability for the user
+        if (_availability.id != null) {
+          await widget.service.deleteAvailabilityForUser(
+            widget.userId,
+            _availability.id!,
+          );
+        }
+      } else {
+        // add an availability for the user
+        await widget.service.createAvailabilityForUser(
+          widget.userId,
+          _availability,
+        );
+      }
+      if (context.mounted) {
+        widget.onAvailabilitySaved();
+      }
+    }
+
+    var theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          Text(
+            DateFormat.yMMMMd().format(widget.date),
+            style: theme.textTheme.bodyLarge,
+          ),
+          Row(
+            children: [
+              Checkbox(
+                value: _clearAvailableToday,
+                onChanged: (value) {
+                  setState(() {
+                    _clearAvailableToday = value!;
+                  });
+                },
+              ),
+              const Text("Clear availability for today"),
+            ],
+          ),
+          Opacity(
+            opacity: _clearAvailableToday ? 0.5 : 1,
+            child: IgnorePointer(
+              ignoring: _clearAvailableToday,
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: GestureDetector(
+                          onTap: updateAvailabilityStart,
+                          child: AbsorbPointer(
+                            child: TextField(
+                              controller: _startDateController,
+                              decoration: const InputDecoration(
+                                labelText: "Begin tijd",
+                                suffixIcon: Icon(Icons.access_time),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      const Text("tot"),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: GestureDetector(
+                          onTap: updateAvailabilityEnd,
+                          child: AbsorbPointer(
+                            child: TextField(
+                              controller: _endDateController,
+                              decoration: const InputDecoration(
+                                labelText: "Eind tijd",
+                                suffixIcon: Icon(Icons.access_time),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  const Text("Add pause (optional)"),
+                  ListView(
+                    shrinkWrap: true,
+                    children: _availability.breaks.map(
+                      (breakModel) {
+                        var start =
+                            DateFormat("HH:mm").format(breakModel.startTime);
+                        var end =
+                            DateFormat("HH:mm").format(breakModel.endTime);
+                        return GestureDetector(
+                          onTap: () async {
+                            var updatedBreak =
+                                await AvailabilityBreakSelectionDialog.show(
+                              context,
+                              breakModel,
+                            );
+                            if (updatedBreak != null) {
+                              setState(() {
+                                _availability.breaks.remove(breakModel);
+                                _availability.breaks.add(updatedBreak);
+                              });
+                            }
+                          },
+                          child: Container(
+                            decoration: const BoxDecoration(
+                              color: Colors.lightBlue,
+                            ),
+                            margin: const EdgeInsets.only(bottom: 16),
+                            padding: const EdgeInsets.all(16),
+                            child: Row(
+                              children: [
+                                Text(
+                                  "${breakModel.duration.inMinutes}"
+                                  " minutes  |  ",
+                                ),
+                                Text(
+                                  "$start - "
+                                  "$end",
+                                ),
+                                const Spacer(),
+                                IconButton(
+                                  icon: const Icon(Icons.delete),
+                                  onPressed: () {
+                                    setState(() {
+                                      _availability.breaks.remove(breakModel);
+                                    });
+                                  },
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ).toList(),
+                  ),
+                  TextButton(
+                    onPressed: onClickAddPause,
+                    child: const Text("Add"),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const Spacer(),
+          ElevatedButton(
+            onPressed: () async => onClickSave(),
+            child: Text(widget.options.translations.availabilitySave),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+///
+class AvailabilityBreakSelectionDialog extends StatefulWidget {
+  ///
+  const AvailabilityBreakSelectionDialog({
+    required this.initialBreak,
+    super.key,
+  });
+
+  /// The initial break to show in the dialog if any
+  final AvailabilityBreakModel? initialBreak;
+
+  /// Opens the dialog to add a break
+  static Future<AvailabilityBreakModel?> show(
+    BuildContext context,
+    AvailabilityBreakModel? initialBreak,
+  ) async =>
+      showDialog<AvailabilityBreakModel>(
+        context: context,
+        builder: (context) => AvailabilityBreakSelectionDialog(
+          initialBreak: initialBreak,
+        ),
+      );
+
+  @override
+  State<AvailabilityBreakSelectionDialog> createState() =>
+      _AvailabilityBreakSelectionDialogState();
+}
+
+class _AvailabilityBreakSelectionDialogState
+    extends State<AvailabilityBreakSelectionDialog> {
+  late TextEditingController _durationController;
+  late TextEditingController _startPauseController;
+  late TextEditingController _endPauseController;
+  late AvailabilityBreakModel _breakModel;
+
+  @override
+  void initState() {
+    super.initState();
+    _breakModel = widget.initialBreak ??
+        AvailabilityBreakModel(
+          startTime: DateTime.now(),
+          endTime: DateTime.now(),
+        );
+    _durationController = TextEditingController(
+      text: _breakModel.duration.inMinutes.toString(),
+    );
+    _startPauseController = TextEditingController(
+      text: DateFormat("HH:mm").format(_breakModel.startTime),
+    );
+    _endPauseController = TextEditingController(
+      text: DateFormat("HH:mm").format(_breakModel.endTime),
+    );
+  }
+
+  @override
+  void dispose() {
+    _durationController.dispose();
+    _startPauseController.dispose();
+    _endPauseController.dispose();
+    super.dispose();
+  }
+
+  Future<TimeOfDay?> _selectTime(
+    BuildContext context,
+    TextEditingController controller,
+  ) async {
+    var picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+    if (picked != null) {
+      setState(() {
+        controller.text = picked.format(context);
+      });
+      return picked;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    void onUpdateDuration() {
+      var duration = int.tryParse(_durationController.text);
+      if (duration != null) {
+        setState(() {
+          _breakModel = _breakModel.copyWith(
+            duration: Duration(minutes: duration),
+          );
+        });
+      }
+    }
+
+    Future<void> onUpdateStart() async {
+      var selectedTime = await _selectTime(context, _startPauseController);
+      if (selectedTime == null) return;
+
+      var updatedStartTime = _breakModel.startTime.copyWith(
+        hour: selectedTime.hour,
+        minute: selectedTime.minute,
+      );
+      setState(() {
+        _breakModel = _breakModel.copyWith(startTime: updatedStartTime);
+      });
+    }
+
+    Future<void> onUpdateEnd() async {
+      var selectedTime = await _selectTime(context, _endPauseController);
+      if (selectedTime == null) return;
+
+      var updatedEndTime = _breakModel.endTime.copyWith(
+        hour: selectedTime.hour,
+        minute: selectedTime.minute,
+      );
+      setState(() {
+        _breakModel = _breakModel.copyWith(endTime: updatedEndTime);
+      });
+    }
+
+    return AlertDialog(
+      title: const Text("Pauze toevoegen"),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // textfield for duration in minutes
+          TextField(
+            controller: _durationController,
+            decoration: const InputDecoration(
+              labelText: "Duration in minutes",
+            ),
+            onChanged: (_) => onUpdateDuration(),
+          ),
+          TextField(
+            controller: _startPauseController,
+            decoration: const InputDecoration(
+              labelText: "Start time",
+              suffixIcon: Icon(Icons.access_time),
+            ),
+            readOnly: true,
+            onTap: () async => onUpdateStart(),
+          ),
+          TextField(
+            controller: _endPauseController,
+            decoration: const InputDecoration(
+              labelText: "End time",
+              suffixIcon: Icon(Icons.access_time),
+            ),
+            readOnly: true,
+            onTap: () async => onUpdateEnd(),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text("Cancel"),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        TextButton(
+          child: const Text("Save"),
+          onPressed: () {
+            Navigator.of(context).pop(_breakModel);
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/packages/flutter_availability/lib/src/screens/availability_overview.dart
+++ b/packages/flutter_availability/lib/src/screens/availability_overview.dart
@@ -1,0 +1,174 @@
+import "package:flutter/material.dart";
+import "package:flutter_availability/src/config/availability_options.dart";
+import "package:flutter_availability_data_interface/flutter_availability_data_interface.dart";
+import "package:intl/intl.dart";
+
+///
+class AvailabilityOverview extends StatefulWidget {
+  ///
+  const AvailabilityOverview({
+    required this.userId,
+    required this.service,
+    required this.options,
+    required this.onDayClicked,
+    required this.onAvailabilityClicked,
+    super.key,
+  });
+
+  /// The user whose availability is being managed
+  final String userId;
+
+  /// The service to use for managing availability
+  final AvailabilityDataInterface service;
+
+  /// The configuration option for the availability overview
+  final AvailabilityOptions options;
+
+  /// Callback for when the user clicks on a day
+  final void Function(DateTime date) onDayClicked;
+
+  /// Callback for when the user clicks on an availability
+  final void Function(AvailabilityModel availability) onAvailabilityClicked;
+
+  @override
+  State<AvailabilityOverview> createState() => _AvailabilityOverviewState();
+}
+
+class _AvailabilityOverviewState extends State<AvailabilityOverview> {
+  Stream<List<AvailabilityModel>>? _availabilityStream;
+
+  void _startLoadingAvailabilities(DateTime start, DateTime end) {
+    setState(() {
+      _availabilityStream = widget.service.getAvailabilityForUser(
+        userId: widget.userId,
+        start: start,
+        end: end,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var theme = Theme.of(context);
+    return Stack(
+      children: [
+        Column(
+          children: [
+            Text(
+              widget.options.translations.calendarTitle,
+              style: theme.textTheme.displaySmall,
+            ),
+            Expanded(
+              child: _availabilityStream == null
+                  ? const Center(
+                      child: Text("Press the button to load availabilities."),
+                    )
+                  : StreamBuilder<List<AvailabilityModel>>(
+                      stream: _availabilityStream,
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Center(
+                            child: CircularProgressIndicator(),
+                          );
+                        } else if (snapshot.hasError) {
+                          return Center(
+                            child: Text("Error: ${snapshot.error}"),
+                          );
+                        } else if (!snapshot.hasData ||
+                            snapshot.data!.isEmpty) {
+                          return const Center(
+                            child: Text("No availabilities found."),
+                          );
+                        } else {
+                          var sortedAvailabilities = snapshot.data!
+                            ..sort(
+                              (a, b) => a.startDate.compareTo(b.startDate),
+                            );
+                          return ListView.builder(
+                            itemCount: snapshot.data!.length,
+                            itemBuilder: (context, index) {
+                              var availability = sortedAvailabilities[index];
+                              return ListTile(
+                                title: Text(
+                                  "Available from ${DateFormat(
+                                    "dd-MM-yyyy HH:mm",
+                                  ).format(availability.startDate)} "
+                                  "\nto \n"
+                                  "${DateFormat("dd-MM-yyyy HH:mm").format(
+                                    availability.endDate,
+                                  )}",
+                                ),
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.delete),
+                                  onPressed: () async {
+                                    if (availability.id == null) {
+                                      return;
+                                    }
+                                    await widget.service
+                                        .deleteAvailabilityForUser(
+                                      widget.userId,
+                                      availability.id!,
+                                    );
+                                  },
+                                ),
+                                onTap: () =>
+                                    widget.onAvailabilityClicked(availability),
+                              );
+                            },
+                          );
+                        }
+                      },
+                    ),
+            ),
+          ],
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ElevatedButton(
+                onPressed: () async {
+                  // ask the user to select a date
+                  var date = await showDatePicker(
+                    context: context,
+                    initialDate: DateTime.now(),
+                    firstDate:
+                        DateTime.now().subtract(const Duration(days: 365)),
+                    lastDate: DateTime.now().add(const Duration(days: 365)),
+                  );
+
+                  if (date == null) {
+                    return;
+                  }
+                  widget.onDayClicked(date);
+                },
+                child: Text(
+                  widget.options.translations.addAvailableDayButtonText,
+                ),
+              ),
+              ElevatedButton(
+                onPressed: () async {
+                  // ask the user to select a date
+                  var dateRange = await showDateRangePicker(
+                    context: context,
+                    firstDate:
+                        DateTime.now().subtract(const Duration(days: 365)),
+                    lastDate: DateTime.now().add(const Duration(days: 365)),
+                  );
+
+                  if (dateRange == null) {
+                    return;
+                  }
+                  _startLoadingAvailabilities(dateRange.start, dateRange.end);
+                },
+                child: const Text("Load availabilities for a date range"),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/flutter_availability/lib/src/service/local_service.dart
+++ b/packages/flutter_availability/lib/src/service/local_service.dart
@@ -1,0 +1,153 @@
+import "dart:async";
+
+import "package:flutter_availability_data_interface/flutter_availability_data_interface.dart";
+
+/// A local implementation of the [AvailabilityDataInterface] that stores data
+///  in memory.
+class LocalAvailabilityDataInterface implements AvailabilityDataInterface {
+  final Map<String, List<AvailabilityModel>> _userAvailabilities = {};
+
+  final StreamController<Map<String, List<AvailabilityModel>>>
+      _availabilityController = StreamController.broadcast();
+
+  void _notifyChanges() {
+    _availabilityController.add(_userAvailabilities);
+  }
+
+  @override
+  Future<List<AvailabilityModel>> applyTemplateForUser(
+    String userId,
+    AvailabilityTemplateModel template,
+    DateTime start,
+    DateTime end,
+  ) async {
+    // Implementation for applying a template
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AvailabilityModel> createAvailabilityForUser(
+    String userId,
+    AvailabilityModel availability,
+  ) async {
+    var availabilities = _userAvailabilities.putIfAbsent(userId, () => []);
+    var newAvailability = availability.copyWith(id: _generateId());
+    availabilities.add(newAvailability);
+    _notifyChanges();
+    return newAvailability;
+  }
+
+  @override
+  Future<AvailabilityTemplateModel> createTemplateForUser(
+    String userId,
+    AvailabilityTemplateModel template,
+  ) {
+    // Implementation for creating a template
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> deleteAvailabilityForUser(
+    String userId,
+    String availabilityId,
+  ) async {
+    var availabilities = _userAvailabilities[userId];
+    if (availabilities != null) {
+      availabilities
+          .removeWhere((availability) => availability.id == availabilityId);
+      _notifyChanges();
+    }
+  }
+
+  @override
+  Future<void> deleteTemplateForUser(String userId, String templateId) {
+    // Implementation for deleting a template
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<AvailabilityModel>> getAvailabilityForUser({
+    required String userId,
+    DateTime? start,
+    DateTime? end,
+  }) =>
+      _availabilityController.stream.map((availabilitiesMap) {
+        var availabilities = availabilitiesMap[userId];
+        if (availabilities != null) {
+          if (start != null && end != null) {
+            return availabilities
+                .where(
+                  (availability) =>
+                      availability.startDate.isBefore(end) &&
+                      availability.endDate.isAfter(start),
+                )
+                .toList();
+          } else {
+            return availabilities;
+          }
+        } else {
+          return [];
+        }
+      });
+
+  @override
+  Stream<AvailabilityModel> getAvailabilityForUserById(
+    String userId,
+    String availabilityId,
+  ) =>
+      _availabilityController.stream.map((availabilitiesMap) {
+        var availabilities = availabilitiesMap[userId];
+        if (availabilities != null) {
+          return availabilities
+              .firstWhere((availability) => availability.id == availabilityId);
+        } else {
+          throw Exception("Availability not found");
+        }
+      });
+
+  @override
+  Stream<AvailabilityTemplateModel> getTemplateForUserById(
+    String userId,
+    String templateId,
+  ) {
+    // Implementation for getting a template by ID
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<AvailabilityTemplateModel>> getTemplatesForUser(String userId) {
+    // Implementation for getting all templates for a user
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AvailabilityModel> updateAvailabilityForUser(
+    String userId,
+    String availabilityId,
+    AvailabilityModel updatedModel,
+  ) async {
+    var availabilities = _userAvailabilities[userId];
+    if (availabilities != null) {
+      var index = availabilities
+          .indexWhere((availability) => availability.id == availabilityId);
+      if (index != -1) {
+        availabilities[index] = updatedModel.copyWith(id: availabilityId);
+        _notifyChanges();
+        return availabilities[index];
+      }
+    }
+    throw Exception("Availability not found");
+  }
+
+  @override
+  Future<AvailabilityTemplateModel> updateTemplateForUser(
+    String userId,
+    String templateId,
+    AvailabilityTemplateModel updatedModel,
+  ) {
+    // Implementation for updating a template
+    throw UnimplementedError();
+  }
+
+  String _generateId() => DateTime.now().millisecondsSinceEpoch.toString();
+}

--- a/packages/flutter_availability/lib/src/userstory/navigator_userstory.dart
+++ b/packages/flutter_availability/lib/src/userstory/navigator_userstory.dart
@@ -1,0 +1,75 @@
+import "package:flutter/material.dart";
+import "package:flutter_availability/src/screens/availability_day_overview.dart";
+import "package:flutter_availability/src/screens/availability_overview.dart";
+import "package:flutter_availability/src/service/local_service.dart";
+import "package:flutter_availability/src/userstory/userstory_configuration.dart";
+import "package:flutter_availability_data_interface/flutter_availability_data_interface.dart";
+
+///
+Widget availabilityNavigatorUserStory(
+  BuildContext context, {
+  AvailabiltyUserstoryConfiguration? configuration,
+}) =>
+    _availabiltyScreenRoute(
+      context,
+      configuration ??
+          AvailabiltyUserstoryConfiguration(
+            service: LocalAvailabilityDataInterface(),
+            getUserId: (_) => "no-user",
+          ),
+    );
+
+Widget _availabiltyScreenRoute(
+  BuildContext context,
+  AvailabiltyUserstoryConfiguration configuration,
+) =>
+    SafeArea(
+      child: Scaffold(
+        body: AvailabilityOverview(
+          service: configuration.service,
+          options: configuration.options,
+          userId: configuration.getUserId(context),
+          onDayClicked: (date) async => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => _avaibiltyDayOverviewRoute(
+                context,
+                configuration,
+                date,
+                null,
+              ),
+            ),
+          ),
+          onAvailabilityClicked: (availability) async =>
+              Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => _avaibiltyDayOverviewRoute(
+                context,
+                configuration,
+                availability.startDate,
+                availability,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+Widget _avaibiltyDayOverviewRoute(
+  BuildContext context,
+  AvailabiltyUserstoryConfiguration configuration,
+  DateTime date,
+  AvailabilityModel? availability,
+) =>
+    SafeArea(
+      child: Scaffold(
+        appBar: AppBar(),
+        body: AvailabilityDayOverview(
+          service: configuration.service,
+          options: configuration.options,
+          userId: configuration.getUserId(context),
+          date: date,
+          initialAvailability: availability,
+          onAvailabilitySaved: () => Navigator.of(context).pop(),
+        ),
+      ),
+    );

--- a/packages/flutter_availability/lib/src/userstory/userstory_configuration.dart
+++ b/packages/flutter_availability/lib/src/userstory/userstory_configuration.dart
@@ -1,0 +1,22 @@
+import "package:flutter/material.dart";
+import "package:flutter_availability/src/config/availability_options.dart";
+import "package:flutter_availability_data_interface/flutter_availability_data_interface.dart";
+
+///
+class AvailabiltyUserstoryConfiguration {
+  ///
+  const AvailabiltyUserstoryConfiguration({
+    required this.service,
+    required this.getUserId,
+    this.options = const AvailabilityOptions(),
+  });
+
+  ///
+  final AvailabilityOptions options;
+
+  ///
+  final AvailabilityDataInterface service;
+
+  ///
+  final Function(BuildContext context) getUserId;
+}

--- a/packages/flutter_availability/pubspec.yaml
+++ b/packages/flutter_availability/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: any
   flutter_availability_data_interface:
     git:
       url: https://github.com/Iconica-Development/flutter_availability

--- a/packages/flutter_availability/test/flutter_availability_test.dart
+++ b/packages/flutter_availability/test/flutter_availability_test.dart
@@ -1,11 +1,7 @@
-import "package:flutter_availability/flutter_availability.dart";
 import "package:flutter_test/flutter_test.dart";
 
 void main() {
-  test("adds one to input values", () {
-    var calculator = Calculator();
-    expect(calculator.addOne(2), 3);
-    expect(calculator.addOne(-7), -6);
-    expect(calculator.addOne(0), 1);
+  test("Expects tests to run", () {
+    expect(true, isTrue);
   });
 }


### PR DESCRIPTION
This adds a basic flow for the availability userstory.
A local interface implementation is included so you can create availabilities in the example app and they will stay there until you restart the app.

The UI is very basic and not finished. For now the flow is that you can create an availability for a specific day. You can start the stream to fech availabilities within a certain daterange and if you click on availabilities you can edit them. Within an availabiliity you can create breaks, modify them and delete them.