### PR TITLE
fix: export the flutter_availability_data_interface from the userstory

### DIFF
--- a/packages/flutter_availability/lib/flutter_availability.dart
+++ b/packages/flutter_availability/lib/flutter_availability.dart
@@ -1,6 +1,8 @@
 ///
 library flutter_availability;
 
+export "package:flutter_availability_data_interface/flutter_availability_data_interface.dart";
+
 export "src/config/availability_options.dart";
 export "src/config/availability_translations.dart";
 export "src/ui/screens/availability_overview.dart";

--- a/packages/flutter_availability/lib/src/routes.dart
+++ b/packages/flutter_availability/lib/src/routes.dart
@@ -1,7 +1,7 @@
 import "package:flutter/material.dart";
-import "package:flutter_availability/flutter_availability.dart";
 import "package:flutter_availability/src/service/availability_service.dart";
 import "package:flutter_availability/src/ui/screens/availability_modification.dart";
+import "package:flutter_availability/src/ui/screens/availability_overview.dart";
 import "package:flutter_availability/src/ui/screens/template_day_modification.dart";
 import "package:flutter_availability/src/ui/screens/template_overview.dart";
 import "package:flutter_availability/src/ui/screens/template_week_modification.dart";


### PR DESCRIPTION
This makes it easier to use the userstory when you need to create your own datainterface implementation