### PR TITLE
Add explanation texts in availability modification screens

### DIFF
--- a/packages/flutter_availability/lib/src/config/availability_translations.dart
+++ b/packages/flutter_availability/lib/src/config/availability_translations.dart
@@ -29,6 +29,9 @@ class AvailabilityTranslations {
     required this.availabilityUsedTemplates,
     required this.availabilityTimeTitle,
     required this.availabilitiesTimeTitle,
+    required this.availabilityTemplateDeviationExplanation,
+    required this.availabilitiesTemplateDeviationExplanation,
+    required this.availabilitiesConflictingTimeExplanation,
     required this.availabilityDialogConfirmTitle,
     required this.availabilityDialogConfirmDescription,
     required this.templateScreenTitle,
@@ -95,6 +98,13 @@ class AvailabilityTranslations {
     this.availabilityUsedTemplates = "Used templates",
     this.availabilityTimeTitle = "Start and end time workday",
     this.availabilitiesTimeTitle = "Start and end time workdays",
+    this.availabilityTemplateDeviationExplanation =
+        "The start and end time are deviating from the template for this day",
+    this.availabilitiesTemplateDeviationExplanation =
+        "The start and end time are deviating from the template for these days",
+    this.availabilitiesConflictingTimeExplanation =
+        "There are conflicting times when applying this template "
+            "for this period",
     this.availabilityDialogConfirmTitle =
         "Are you sure you want to save the changes?",
     this.availabilityDialogConfirmDescription =
@@ -203,6 +213,18 @@ class AvailabilityTranslations {
 
   /// The title on the time selection section for adding multiple availabilities
   final String availabilitiesTimeTitle;
+
+  /// The explainer text when the availability deviates from the used template
+  /// on the availability modification screen
+  final String availabilityTemplateDeviationExplanation;
+
+  /// The explainer text when one of the availabilities deviates from the used
+  /// template on the availability modification screen
+  final String availabilitiesTemplateDeviationExplanation;
+
+  /// The explainer text when the availabilities have conflicting times when
+  /// applying a template and the start and end time have not been filled in
+  final String availabilitiesConflictingTimeExplanation;
 
   /// The title on the dialog for confirming the availability update
   final String availabilityDialogConfirmTitle;

--- a/packages/flutter_availability/lib/src/ui/screens/availability_modification.dart
+++ b/packages/flutter_availability/lib/src/ui/screens/availability_modification.dart
@@ -183,17 +183,13 @@ class _AvailabilitiesModificationScreenState
     }
 
     return _AvailabilitiesModificationScreenLayout(
-      dateRange: widget.dateRange,
-      clearAvailability: _availabilityViewModel.clearAvailability,
+      viewModel: _availabilityViewModel,
       onClearSection: onClearSection,
       selectedTemplates: _availabilityViewModel.templates,
       onTemplateSelected: onTemplateSelected,
       onTemplatesRemoved: onTemplatesRemoved,
-      startTime: _availabilityViewModel.startTime,
-      endTime: _availabilityViewModel.endTime,
       onStartChanged: onStartChanged,
       onEndChanged: onEndChanged,
-      breaks: _availabilityViewModel.breaks,
       onBreaksChanged: onBreaksChanged,
       sidePadding: spacing.sidePadding,
       bottomButtonPadding: spacing.bottomButtonPadding,
@@ -205,17 +201,13 @@ class _AvailabilitiesModificationScreenState
 
 class _AvailabilitiesModificationScreenLayout extends HookWidget {
   const _AvailabilitiesModificationScreenLayout({
-    required this.dateRange,
-    required this.clearAvailability,
+    required this.viewModel,
     required this.onClearSection,
     required this.selectedTemplates,
     required this.onTemplateSelected,
     required this.onTemplatesRemoved,
-    required this.startTime,
-    required this.endTime,
     required this.onStartChanged,
     required this.onEndChanged,
-    required this.breaks,
     required this.onBreaksChanged,
     required this.sidePadding,
     required this.bottomButtonPadding,
@@ -223,8 +215,7 @@ class _AvailabilitiesModificationScreenLayout extends HookWidget {
     required this.onExit,
   });
 
-  final DateTimeRange dateRange;
-  final bool clearAvailability;
+  final AvailabilityViewModel viewModel;
   // ignore: avoid_positional_boolean_parameters
   final void Function(bool isChecked) onClearSection;
 
@@ -232,12 +223,9 @@ class _AvailabilitiesModificationScreenLayout extends HookWidget {
   final void Function() onTemplateSelected;
   final void Function() onTemplatesRemoved;
 
-  final TimeOfDay? startTime;
-  final TimeOfDay? endTime;
   final void Function(TimeOfDay start) onStartChanged;
   final void Function(TimeOfDay start) onEndChanged;
 
-  final List<BreakViewModel> breaks;
   final void Function(List<BreakViewModel> breaks) onBreaksChanged;
 
   final double sidePadding;
@@ -258,11 +246,11 @@ class _AvailabilitiesModificationScreenLayout extends HookWidget {
       BasePage(
         body: [
           AvailabilityClearSection(
-            range: dateRange,
-            clearAvailable: clearAvailability,
+            range: viewModel.selectedRange,
+            clearAvailable: viewModel.clearAvailability,
             onChanged: onClearSection,
           ),
-          if (!clearAvailability) ...[
+          if (!viewModel.clearAvailability) ...[
             const SizedBox(height: 24),
             AvailabilityTemplateSelection(
               selectedTemplates: selectedTemplates,
@@ -271,16 +259,14 @@ class _AvailabilitiesModificationScreenLayout extends HookWidget {
             ),
             const SizedBox(height: 24),
             AvailabilityTimeSelection(
-              dateRange: dateRange,
-              startTime: startTime,
-              endTime: endTime,
-              key: ValueKey([startTime, endTime]),
+              viewModel: viewModel,
+              key: ValueKey(viewModel),
               onStartChanged: onStartChanged,
               onEndChanged: onEndChanged,
             ),
             const SizedBox(height: 24),
             PauseSelection(
-              breaks: breaks,
+              breaks: viewModel.breaks,
               editingTemplate: false,
               onBreaksChanged: onBreaksChanged,
             ),

--- a/packages/flutter_availability/lib/src/ui/view_models/availability_view_model.dart
+++ b/packages/flutter_availability/lib/src/ui/view_models/availability_view_model.dart
@@ -130,6 +130,10 @@ class AvailabilityViewModel {
       templateSelected ||
       (startTime != null && endTime != null);
 
+  /// Whether a message should be shown to the user that the start and end times
+  /// are conflicting and they can't be filled in automatically
+  bool get showConflictingMessage => templateSelected && conflictingTime;
+
   /// Whether a template deviation should be shown to the user
   bool get isDeviatingFromTemplate =>
       startTime != null &&

--- a/packages/flutter_availability/lib/src/ui/widgets/availabillity_time_selection.dart
+++ b/packages/flutter_availability/lib/src/ui/widgets/availabillity_time_selection.dart
@@ -40,6 +40,8 @@ class AvailabilityTimeSelection extends StatelessWidget {
       explanationText = isSingleDay
           ? translations.availabilityTemplateDeviationExplanation
           : translations.availabilitiesTemplateDeviationExplanation;
+    } else if (viewModel.showConflictingMessage) {
+      explanationText = translations.availabilitiesConflictingTimeExplanation;
     }
 
     return Column(
@@ -68,6 +70,7 @@ class _AvailabilityExplanation extends StatelessWidget {
     required this.explanation,
   });
 
+  /// The explanation text to show to the user
   final String explanation;
 
   @override

--- a/packages/flutter_availability/lib/src/ui/widgets/availabillity_time_selection.dart
+++ b/packages/flutter_availability/lib/src/ui/widgets/availabillity_time_selection.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:flutter_availability/src/ui/view_models/availability_view_model.dart";
 import "package:flutter_availability/src/ui/widgets/generic_time_selection.dart";
 import "package:flutter_availability/src/util/scope.dart";
 
@@ -6,19 +7,14 @@ import "package:flutter_availability/src/util/scope.dart";
 class AvailabilityTimeSelection extends StatelessWidget {
   ///
   const AvailabilityTimeSelection({
-    required this.startTime,
-    required this.endTime,
+    required this.viewModel,
     required this.onStartChanged,
     required this.onEndChanged,
-    required this.dateRange,
     super.key,
   });
 
   ///
-  final TimeOfDay? startTime;
-
-  ///
-  final TimeOfDay? endTime;
+  final AvailabilityViewModel viewModel;
 
   ///
   final void Function(TimeOfDay) onStartChanged;
@@ -26,27 +22,65 @@ class AvailabilityTimeSelection extends StatelessWidget {
   ///
   final void Function(TimeOfDay) onEndChanged;
 
-  /// The date range for which the availabilities are being managed
-  final DateTimeRange dateRange;
-
   @override
   Widget build(BuildContext context) {
     var availabilityScope = AvailabilityScope.of(context);
     var options = availabilityScope.options;
     var translations = options.translations;
 
+    var dateRange = viewModel.selectedRange;
+
     var isSingleDay = dateRange.start.isAtSameMomentAs(dateRange.end);
     var titleText = isSingleDay
         ? translations.availabilityTimeTitle
         : translations.availabilitiesTimeTitle;
 
-    return TimeSelection(
-      title: titleText,
-      description: null,
-      startTime: startTime,
-      endTime: endTime,
-      onStartChanged: onStartChanged,
-      onEndChanged: onEndChanged,
+    String? explanationText;
+    if (viewModel.isDeviatingFromTemplate) {
+      explanationText = isSingleDay
+          ? translations.availabilityTemplateDeviationExplanation
+          : translations.availabilitiesTemplateDeviationExplanation;
+    }
+
+    return Column(
+      children: [
+        TimeSelection(
+          title: titleText,
+          description: null,
+          startTime: viewModel.startTime,
+          endTime: viewModel.endTime,
+          onStartChanged: onStartChanged,
+          onEndChanged: onEndChanged,
+        ),
+        if (explanationText != null) ...[
+          const SizedBox(height: 8),
+          _AvailabilityExplanation(
+            explanation: explanationText,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _AvailabilityExplanation extends StatelessWidget {
+  const _AvailabilityExplanation({
+    required this.explanation,
+  });
+
+  final String explanation;
+
+  @override
+  Widget build(BuildContext context) {
+    var theme = Theme.of(context);
+    var textTheme = theme.textTheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Icon(Icons.info_outline),
+        const SizedBox(width: 8),
+        Expanded(child: Text(explanation, style: textTheme.bodyMedium)),
+      ],
     );
   }
 }


### PR DESCRIPTION
When there are template deviations or the start/end time can't be filled in due to conflicts. A message will be shown to the user.