### PR TITLE
final UI fixes breaks

### DIFF
--- a/packages/flutter_availability/lib/src/ui/widgets/pause_selection.dart
+++ b/packages/flutter_availability/lib/src/ui/widgets/pause_selection.dart
@@ -211,6 +211,7 @@ class AvailabilityBreakSelectionDialog extends StatefulWidget {
       showModalBottomSheet<BreakViewModel>(
         context: context,
         useSafeArea: false,
+        isScrollControlled: true,
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.only(
             topLeft: Radius.circular(10),

--- a/packages/flutter_availability/lib/src/ui/widgets/pause_selection.dart
+++ b/packages/flutter_availability/lib/src/ui/widgets/pause_selection.dart
@@ -328,15 +328,19 @@ class _AvailabilityBreakSelectionDialogState
                 const SizedBox(height: 16),
                 Row(
                   children: [
-                    const Spacer(),
+                    const Spacer(
+                      flex: 3,
+                    ),
                     Expanded(
-                      flex: 2,
+                      flex: 4,
                       child: DurationInputField(
                         initialValue: _breakViewModel.submittedDuration,
                         onDurationChanged: onUpdateDuration,
                       ),
                     ),
-                    const Spacer(),
+                    const Spacer(
+                      flex: 3,
+                    ),
                   ],
                 ),
                 const SizedBox(height: 24),


### PR DESCRIPTION
The duration did not have the same width, so using higher flex values it allows for the proper ratios.

The isScrollControlled allows the modal to grow beyond the 50% screenheight. Tested on various screen heights to validate